### PR TITLE
Report generation issues

### DIFF
--- a/classes/task/generate_report.php
+++ b/classes/task/generate_report.php
@@ -142,6 +142,10 @@ class generate_report extends adhoc_task {
             $cleanrecord->encoded_size = max(array_map(function($column) use ($record) {
                 return $record->{$column . '_size'} ?? 0;
             }, explode(',', $this->get_custom_data()->columns)));
+            // Apply size setting filter.
+            if ($cleanrecord->encoded_size < (get_config('tool_encoded', 'size') * 1024)) {
+                return false;
+            }
             $cleanrecord->native_id = (int) $record->id;
             $cleanrecord->pid = $this->get_pid();
             $cleanrecord->report_table = $this->get_custom_data()->table;

--- a/classes/task/generate_report.php
+++ b/classes/task/generate_report.php
@@ -56,6 +56,11 @@ class generate_report extends adhoc_task {
     public function execute(): void {
         global $DB;
         $stime = time();
+
+        // Large tables may take time and memory.
+        \core_php_time_limit::raise();
+        raise_memory_limit(MEMORY_HUGE);
+
         $records = $this->search_columns();
         // Make a deep clone of the records just in case other functions need the raw data.
         $preppedrecords = $this->extend_records(unserialize(serialize($records)));

--- a/tests/local/entities/records_test.php
+++ b/tests/local/entities/records_test.php
@@ -41,6 +41,8 @@ class records_test extends \advanced_testcase {
         global $DB;
         $this->resetAfterTest();
         $this->setAdminUser();
+        // Disable size filter for tests as examples are under the default size.
+        set_config('size', 0, 'tool_encoded');
 
         $DB->insert_record('workshop_assessments', [
             'submissionid' => '2',

--- a/tests/local/systemreports/records_test.php
+++ b/tests/local/systemreports/records_test.php
@@ -35,6 +35,8 @@ class records_test extends \advanced_testcase {
         global $DB;
         $this->resetAfterTest();
         $this->setAdminUser();
+        // Disable size filter for tests as tests are under the default size.
+        set_config('size', 0, 'tool_encoded');
 
         $DB->insert_record('workshop_assessments', [
             'submissionid' => '2',

--- a/tests/task/generate_report_test.php
+++ b/tests/task/generate_report_test.php
@@ -88,7 +88,7 @@ class generate_report_test extends \advanced_testcase {
                 'workshop_assessments',
                 'feedbackauthor',
                 [
-                    'encoded_size' => 67,
+                    'encoded_size' => 113,
                     'mimetype' => 'data:image/gif;',
                     'pid' => 0,
                     'report_table' => 'workshop_assessments',

--- a/tests/task/generate_report_test.php
+++ b/tests/task/generate_report_test.php
@@ -41,6 +41,9 @@ class generate_report_test extends \advanced_testcase {
     public function test_task($table,  $columns,  $records): void {
         global $DB;
         $this->resetAfterTest();
+        // Disable size filter for tests as examples are under the default size.
+        set_config('size', 0, 'tool_encoded');
+
         $recordid = $DB->insert_record($table, [
             'submissionid' => '2',
             'reviewerid' => '2',

--- a/tests/task/generate_report_test.php
+++ b/tests/task/generate_report_test.php
@@ -89,7 +89,7 @@ class generate_report_test extends \advanced_testcase {
                 'feedbackauthor',
                 [
                     'encoded_size' => 113,
-                    'mimetype' => 'data:image/gif;',
+                    'mimetype' => 'image/gif',
                     'pid' => 0,
                     'report_table' => 'workshop_assessments',
                     'report_columns' => 'feedbackauthor',


### PR DESCRIPTION
Notes:

1. I've changed how size is calculated from size of the base64 file to size of the full column. This does lose a little bit of accuracy - especially when things are embedded in large HTML chunks, but loading the entire base64 file is not realistic for potential large files.
2. The increase to time and memory weren't needed in my local setup after the other changes, but scanning large databases can still take time so I think it's best to keep these. 
3. The SQL search has performed slightly worse in my testing (some tables 1-2s instead of <1s). 
4. I've made some assumptions around the metadata portion of base64 data, including that this is less than 80 characters and the metadata part will always end with `;base64`. This should be verified.

Closes #16 
Closes #7
Closes #14 