### PR TITLE
Fix ad hoc task issues

### DIFF
--- a/classes/task/generate_report.php
+++ b/classes/task/generate_report.php
@@ -46,7 +46,7 @@ class generate_report extends adhoc_task {
             'columns' => $columns,
         ]);
         // Queue the task for the next run.
-        manager::queue_adhoc_task($task);
+        manager::queue_adhoc_task($task, true);
     }
 
     /**

--- a/classes/task/migrate.php
+++ b/classes/task/migrate.php
@@ -59,7 +59,8 @@ class migrate extends adhoc_task {
         $conditions = [
             'migrated' => 0,
         ];
-        if (!empty($recordid = $this->get_custom_data()->recordid)) {
+        $recordid = $this->get_custom_data()->recordid;
+        if (!empty($recordid)) {
             $conditions['id'] = $recordid;
         }
 
@@ -85,9 +86,13 @@ class migrate extends adhoc_task {
         $success = false;
         // Find the associated table and columns to attempt to replace data within.
         $storedrecord = $DB->get_record($record->report_table, ['id' => $record->native_id]);
+        if (empty($storedrecord)) {
+            return false;
+        }
         // Decode the encoded data.
         $column = $record->report_column;
-        if (!$updatedtext = $this->decode_data($record, $storedrecord->{$column})) {
+        $data = $storedrecord->{$column} ?? '';
+        if (!$data || !$updatedtext = $this->decode_data($record, $data)) {
             return false;
         }
         // Set the column to the link to the file.

--- a/classes/task/migrate.php
+++ b/classes/task/migrate.php
@@ -41,7 +41,7 @@ class migrate extends adhoc_task {
             'recordid' => $recordid,
         ]);
         // Queue the task for the next run.
-        manager::queue_adhoc_task($task);
+        manager::queue_adhoc_task($task, true);
     }
 
     /**

--- a/index.php
+++ b/index.php
@@ -42,7 +42,7 @@ if (!$context = context_system::instance()) {
 
 require_capability('moodle/site:configview', $context);
 
-$url = new moodle_url('/admin/tool/encoded/index.php');
+$url = new moodle_url('/admin/tool/encoded/index.php', ['action' => $action]);
 
 // Display the page.
 $PAGE->set_context(context_system::instance());
@@ -60,17 +60,19 @@ if (data_submitted() && confirm_sesskey()) {
         } else {
             generate_report::queue($form->table, $form->columns);
         }
-        echo notification::success(get_string('generatenotification', 'tool_encoded'));
+        notification::success(get_string('generatenotification', 'tool_encoded'));
     } else if ($action === 'migrate') {
         if (isset($form->recordid)) {
             migrate::queue($form->recordid);
             if ($form->recordid == 0) {
-                echo notification::success(get_string('migratenotificationall', 'tool_encoded'));
+                notification::success(get_string('migratenotificationall', 'tool_encoded'));
             } else {
-                echo notification::success(get_string('migratenotification', 'tool_encoded', $form->recordid));
+                notification::success(get_string('migratenotification', 'tool_encoded', $form->recordid));
             }
         }
     }
+    // Redirect to prevent multiple submits.
+    redirect($url);
 }
 
 if ($action === 'report' || $action === 'migrate') {

--- a/version.php
+++ b/version.php
@@ -25,6 +25,6 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'tool_encoded';
-$plugin->version = 2024050600;
+$plugin->version = 2025041500;
 $plugin->requires = 2022112800;
 $plugin->supported = [401, 405];


### PR DESCRIPTION
`c13d1a0d8345:2068977 2025-04-15 12:10:48 Adhoc task failed: tool_encoded\task\migrate,tool_encoded\task\migrate::decode_data(): Argument #2 ($data) must be of type string, null given, called in /var/www/site/admin/tool/encoded/classes/task/migrate.php on line 90`

1. Fixes above adhoc task error
2. Prevents multiple submits
3. Uses checkforexisting flag to prevent duplicate tasks