### PR TITLE
Add preferred extensions for mimetypes #22

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -32,6 +32,21 @@ class helper {
     /** @var string Context used for questions in mapping because it is variable */
     public const CONTEXT_QUESTION = 'question';
 
+    /** @var array Preferred extensions to use for mimetypes */
+    public const PREFERRED_EXTENSIONS = [
+        'image/jpeg'        => 'jpg',
+        'image/png'         => 'png',
+        'image/gif'         => 'gif',
+        'text/plain'        => 'txt',
+        'text/xml'          => 'xml',
+        'application/pdf'   => 'pdf',
+        'application/zip'   => 'zip',
+        'application/gzip'  => 'gz',
+        'audio/mpeg'        => 'mp3',
+        'video/mp4'         => 'mp4',
+        'video/quicktime'   => 'mov',
+    ];
+
     /**
      * Mapping that helps handle report generation and migrations.
      *

--- a/classes/task/migrate.php
+++ b/classes/task/migrate.php
@@ -224,7 +224,7 @@ class migrate extends adhoc_task {
             }
             if (strrpos($mimetype, $info['type']) !== false) {
                 $data = new stdClass();
-                $data->extension = $extension;
+                $data->extension = helper::PREFERRED_EXTENSIONS[$mimetype] ?? $extension;
                 $data->type = $info['type'];
                 $data->group = $info['groups'][0] ?? null;
                 return $data;


### PR DESCRIPTION
There's no simple one size fits all source without using third party libraries, so I've added preferred mapping for the most common extensions to avoid the main issues with common file types.

Closes #22 