### PR TITLE
Improve regex for base64 URIs

### DIFF
--- a/classes/task/migrate.php
+++ b/classes/task/migrate.php
@@ -83,66 +83,81 @@ class migrate extends adhoc_task {
      */
     private function migrate_record(stdClass $record): bool {
         global $DB;
-        $success = false;
-        // Find the associated table and columns to attempt to replace data within.
-        $storedrecord = $DB->get_record($record->report_table, ['id' => $record->native_id]);
-        if (empty($storedrecord)) {
+
+        // Fetch the referenced record.
+        $tablename = $record->report_table;
+        $columnname = $record->report_column;
+        $referenced = $DB->get_record($tablename, ['id' => $record->native_id]);
+
+        // If the referenced record does not exist, we cannot migrate.
+        if ($referenced === false) {
             return false;
         }
-        // Decode the encoded data.
-        $column = $record->report_column;
-        $data = $storedrecord->{$column} ?? '';
-        if (!$data || !$updatedtext = $this->decode_data($record, $data)) {
+
+        // Fetch the data from the referenced record.
+        $data = $referenced->{$columnname};
+
+        // If the data is empty or not a string, we cannot migrate.
+        if (empty($data) || !is_string($data)) {
             return false;
         }
-        // Set the column to the link to the file.
-        $storedrecord->{$column} = $updatedtext;
-        $storedrecord->timemodified = time();
-        if ($DB->update_record($record->report_table, $storedrecord)) {
-            $success = true;
-        } else {
-            $success = false;
+
+        // Find all base64 attributes in the data.
+        $results = self::find_base64_uris($data);
+
+        // Generate pluginfile references for each base64 URI.
+        $uris = [];
+        $pluginfiles = [];
+        foreach ($results as $result) {
+            $pluginfile = $this->convert_to_pluginfile($record, $result->decoded);
+
+            if (!empty($pluginfile)) {
+                $uris[] = $result->uri;
+                $pluginfiles[] = $pluginfile;
+            }
         }
 
-        if ($success) {
-            // File was written successfully and the record updated.
-            return true;
+        // If we have no pluginfiles, we cannot migrate.
+        if (empty($pluginfiles)) {
+            return false;
         }
 
-        // File was not written successfully and there was an issue.
-        return false;
+        // Replace the base64 URIs with pluginfile references.
+        $data = str_replace($uris, $pluginfiles, $data);
+
+        // Update the referenced record with the new data.
+        $referenced->{$columnname} = $data;
+        $referenced->timemodified = time();
+        $DB->update_record($tablename, $referenced);
+
+        return true;
     }
 
     /**
-     * Decodes base64 data stored in the database and replaces it with a pluginfile.
+     * Finds all src attributes with base64 data URIs in the given string.
      *
-     * @param stdClass $record
-     * @param string $data
-     * @return string
+     * @param string $data The complete string to search.
+     * @return array An array of objects with 'uri' and 'decoded' properties.
      */
-    private function decode_data(stdClass $record, string $data): string {
-        preg_match_all('/src="([^"]+)"/', $data, $matches);
-        if (empty($srcs = $matches[1])) {
-            return '';
+    public static function find_base64_uris(string $data): array {
+        $pattern = '/src\s*=\s*(["\'])(data:([^;]+);base64,([^"\']+))\1/is';
+        preg_match_all($pattern, $data, $matches, PREG_SET_ORDER);
+
+        $results = [];
+        foreach ($matches as $match) {
+            $decoded = base64_decode($match[4]);
+
+            if ($decoded === false) {
+                continue;
+            }
+
+            $results[] = (object) [
+                'uri' => $match[2],
+                'decoded' => $decoded,
+            ];
         }
 
-        // TODO: Improve efficiency by not storing the base64 string multiple times.
-        $changes = false;
-        $check = "base64,";
-        foreach ($srcs as $src) {
-            $start = strrpos($src, $check);
-            if ($start === false) {
-                continue;
-            }
-            $base64string = substr($src, $start + strlen($check));
-            $decodeddata = base64_decode($base64string);
-            if (!$pluginfile = $this->convert_to_pluginfile($record, $decodeddata)) {
-                continue;
-            }
-            $data = str_replace($src, $pluginfile, $data);
-            $changes = true;
-        }
-        return ($changes) ? $data : '';
+        return $results;
     }
 
     /**

--- a/classes/task/migrate.php
+++ b/classes/task/migrate.php
@@ -95,7 +95,7 @@ class migrate extends adhoc_task {
         }
 
         // Fetch the data from the referenced record.
-        $data = $referenced->{$columnname};
+        $data = $referenced->{$columnname} ?? null;
 
         // If the data is empty or not a string, we cannot migrate.
         if (empty($data) || !is_string($data)) {

--- a/classes/task/migrate.php
+++ b/classes/task/migrate.php
@@ -134,14 +134,19 @@ class migrate extends adhoc_task {
     }
 
     /**
-     * Finds all src attributes with base64 data URIs in the given string.
+     * Finds all src and url attributes with base64 data URIs in the given string.
      *
      * @param string $data The complete string to search.
      * @return array An array of objects with 'uri' and 'decoded' properties.
      */
     public static function find_base64_uris(string $data): array {
-        $pattern = '/src\s*=\s*(["\'])(data:([^;]+);base64,([^"\']+))\1/is';
-        preg_match_all($pattern, $data, $matches, PREG_SET_ORDER);
+        $srcpattern = '/src\s*=\s*(["\'])(\s*data:([^;]+);base64,([^"\']+)\s*)\1/is';
+        $urlpattern = '/url\(\s*(["\']?)(\s*data:([^;]+);base64,([^"\']+))\s*\1\s*\)/is';
+
+        preg_match_all($srcpattern, $data, $srcmatches, PREG_SET_ORDER);
+        preg_match_all($urlpattern, $data, $urlmatches, PREG_SET_ORDER);
+
+        $matches = array_merge($srcmatches, $urlmatches);
 
         $results = [];
         foreach ($matches as $match) {
@@ -152,7 +157,7 @@ class migrate extends adhoc_task {
             }
 
             $results[] = (object) [
-                'uri' => $match[2],
+                'uri' => trim($match[2]),
                 'decoded' => $decoded,
             ];
         }

--- a/tests/task/migrate_test.php
+++ b/tests/task/migrate_test.php
@@ -197,63 +197,54 @@ final class migrate_test extends advanced_testcase {
         $gifdecoded = base64_decode($gif);
 
         return [
-            // Empty string.
-            [
+            'empty string' => [
                 'input' => '',
                 'expected' => [],
             ],
-            // No base64.
-            [
+            'no base64' => [
                 'input' => '<img src="/path/to/image.jpg">',
                 'expected' => [],
             ],
-            // PNG single quotes.
-            [
+            'png single quotes' => [
                 'input' => "<img src='{$pnguri}'>",
                 'expected' => [
                     (object) ['uri' => $pnguri, 'decoded' => $pngdecoded],
                 ],
             ],
-            // PNG double quotes.
-            [
+            'png double quotes' => [
                 'input' => "<img src=\"{$pnguri}\">",
                 'expected' => [
                     (object) ['uri' => $pnguri, 'decoded' => $pngdecoded],
                 ],
             ],
-            // PNG and GIF single quotes.
-            [
+            'png and gif single quotes' => [
                 'input' => "<img src='{$pnguri}'><img src='{$gifuri}'>",
                 'expected' => [
                     (object) ['uri' => $pnguri, 'decoded' => $pngdecoded],
                     (object) ['uri' => $gifuri, 'decoded' => $gifdecoded],
                 ],
             ],
-            // PNG and GIF double quotes.
-            [
+            'png and gif double quotes' => [
                 'input' => "<img src=\"{$pnguri}\"><img src=\"{$gifuri}\">",
                 'expected' => [
                     (object) ['uri' => $pnguri, 'decoded' => $pngdecoded],
                     (object) ['uri' => $gifuri, 'decoded' => $gifdecoded],
                 ],
             ],
-            // PNG and GIF mixed quotes.
-            [
+            'png and gif mixed quotes' => [
                 'input' => "<img src='{$pnguri}'><img src=\"{$gifuri}\">",
                 'expected' => [
                     (object) ['uri' => $pnguri, 'decoded' => $pngdecoded],
                     (object) ['uri' => $gifuri, 'decoded' => $gifdecoded],
                 ],
             ],
-            // PNG with caps.
-            [
+            'png with caps' => [
                 'input' => "<IMG SRC=\"{$pnguri}\">",
                 'expected' => [
                     (object) ['uri' => $pnguri, 'decoded' => $pngdecoded],
                 ],
             ],
-            // PNG and GIF and no base64 with mixed quotes and caps and whitespace.
-            [
+            'complex mixed case and whitespace' => [
                 'input' => "<IMG SRC= '{$pnguri}'><img src =\"{$gifuri}\"><img src = '/path/to/image.jpg'>",
                 'expected' => [
                     (object) ['uri' => $pnguri, 'decoded' => $pngdecoded],

--- a/tests/task/migrate_test.php
+++ b/tests/task/migrate_test.php
@@ -171,6 +171,100 @@ class migrate_test extends advanced_testcase {
     }
 
     /**
+     * Test the find_base64_uris method.
+     *
+     * @dataProvider find_base64_uris_provider
+     * @param string $input
+     * @param array $expected
+     */
+    public function test_find_base64_uris(string $input, array $expected): void {
+        $actual = migrate::find_base64_uris($input);
+        self::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Data provider for test_find_base64_uris.
+     *
+     * @return array
+     */
+    public static function find_base64_uris_provider(): array {
+        $png = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQAAAAA3bvkkAAAACklEQVR4AWNgAAAAAgABc3UBGAAA
+                AABJRU5ErkJggg==';
+        $pnguri = "data:image/png;base64,{$png}";
+        $pngdecoded = base64_decode($png);
+
+        $gif = 'R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
+        $gifuri = "data:image/gif;base64,{$gif}";
+        $gifdecoded = base64_decode($gif);
+
+        return [
+            // Empty string.
+            [
+                'input' => '',
+                'expected' => [],
+            ],
+            // No base64.
+            [
+                'input' => '<img src="/path/to/image.jpg">',
+                'expected' => [],
+            ],
+            // PNG single quotes.
+            [
+                'input' => "<img src='{$pnguri}'>",
+                'expected' => [
+                    (object) ['uri' => $pnguri, 'decoded' => $pngdecoded],
+                ],
+            ],
+            // PNG double quotes.
+            [
+                'input' => "<img src=\"{$pnguri}\">",
+                'expected' => [
+                    (object) ['uri' => $pnguri, 'decoded' => $pngdecoded],
+                ],
+            ],
+            // PNG and GIF single quotes.
+            [
+                'input' => "<img src='{$pnguri}'><img src='{$gifuri}'>",
+                'expected' => [
+                    (object) ['uri' => $pnguri, 'decoded' => $pngdecoded],
+                    (object) ['uri' => $gifuri, 'decoded' => $gifdecoded],
+                ],
+            ],
+            // PNG and GIF double quotes.
+            [
+                'input' => "<img src=\"{$pnguri}\"><img src=\"{$gifuri}\">",
+                'expected' => [
+                    (object) ['uri' => $pnguri, 'decoded' => $pngdecoded],
+                    (object) ['uri' => $gifuri, 'decoded' => $gifdecoded],
+                ],
+            ],
+            // PNG and GIF mixed quotes.
+            [
+                'input' => "<img src='{$pnguri}'><img src=\"{$gifuri}\">",
+                'expected' => [
+                    (object) ['uri' => $pnguri, 'decoded' => $pngdecoded],
+                    (object) ['uri' => $gifuri, 'decoded' => $gifdecoded],
+                ],
+            ],
+            // PNG with caps.
+            [
+                'input' => "<IMG SRC=\"{$pnguri}\">",
+                'expected' => [
+                    (object) ['uri' => $pnguri, 'decoded' => $pngdecoded],
+                ],
+            ],
+            // PNG and GIF and no base64 with mixed quotes and caps and whitespace.
+            [
+                'input' => "<IMG SRC= '{$pnguri}'><img src =\"{$gifuri}\"><img src = '/path/to/image.jpg'>",
+                'expected' => [
+                    (object) ['uri' => $pnguri, 'decoded' => $pngdecoded],
+                    (object) ['uri' => $gifuri, 'decoded' => $gifdecoded],
+                ],
+            ],
+        ];
+    }
+
+    /**
      * Generate a report by table.
      *
      * @param string $table

--- a/tests/task/migrate_test.php
+++ b/tests/task/migrate_test.php
@@ -23,8 +23,6 @@ use dml_exception;
 use stdClass;
 use stored_file;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Unit tests.
  *
@@ -33,11 +31,12 @@ defined('MOODLE_INTERNAL') || die();
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @covers    \tool_encoded\task\migrate
  */
-class migrate_test extends advanced_testcase {
+final class migrate_test extends advanced_testcase {
     /**
      * Set up before each test.
      */
     protected function setUp(): void {
+        parent::setUp();
         $this->resetAfterTest();
         set_config(
             'size',

--- a/tests/task/migrate_test.php
+++ b/tests/task/migrate_test.php
@@ -251,6 +251,22 @@ final class migrate_test extends advanced_testcase {
                     (object) ['uri' => $gifuri, 'decoded' => $gifdecoded],
                 ],
             ],
+            'png missing closing single quote' => [
+                'input' => "<img src='{$pnguri}",
+                'expected' => [],
+            ],
+            'png missing closing double quote' => [
+                'input' => "<img src=\"{$pnguri}",
+                'expected' => [],
+            ],
+            'png mismatched quotes' => [
+                'input' => "<img src='{$pnguri}\">",
+                'expected' => [],
+            ],
+            'gif mismatched quotes' => [
+                'input' => "<img src=\"{$gifuri}'>",
+                'expected' => [],
+            ],
         ];
     }
 

--- a/tests/task/migrate_test.php
+++ b/tests/task/migrate_test.php
@@ -245,7 +245,7 @@ final class migrate_test extends advanced_testcase {
                 ],
             ],
             'complex mixed case and whitespace' => [
-                'input' => "<IMG SRC= '{$pnguri}'><img src =\"{$gifuri}\"><img src = '/path/to/image.jpg'>",
+                'input' => "<IMG SRC= '{$pnguri}'><img src =\" {$gifuri} \"><img src = '/path/to/image.jpg'>",
                 'expected' => [
                     (object) ['uri' => $pnguri, 'decoded' => $pngdecoded],
                     (object) ['uri' => $gifuri, 'decoded' => $gifdecoded],
@@ -266,6 +266,43 @@ final class migrate_test extends advanced_testcase {
             'gif mismatched quotes' => [
                 'input' => "<img src=\"{$gifuri}'>",
                 'expected' => [],
+            ],
+            'png url no quotes' => [
+                'input' => "<style>body { background-image: url({$pnguri}); }</style>",
+                'expected' => [
+                    (object) ['uri' => $pnguri, 'decoded' => $pngdecoded],
+                ],
+            ],
+            'png url single quotes' => [
+                'input' => "<style>body { background-image: url('{$pnguri}'); }</style>",
+                'expected' => [
+                    (object) ['uri' => $pnguri, 'decoded' => $pngdecoded],
+                ],
+            ],
+            'png url double quotes' => [
+                'input' => "<style>body { background-image: url(\"{$pnguri}\"); }</style>",
+                'expected' => [
+                    (object) ['uri' => $pnguri, 'decoded' => $pngdecoded],
+                ],
+            ],
+            'png url whitespace' => [
+                'input' => "<style>body { background-image: url( {$pnguri} ); }</style>",
+                'expected' => [
+                    (object) ['uri' => $pnguri, 'decoded' => $pngdecoded],
+                ],
+            ],
+            'gif url whitespace' => [
+                'input' => "<style>body { background-image: url( ' {$gifuri} ' ); }</style>",
+                'expected' => [
+                    (object) ['uri' => $gifuri, 'decoded' => $gifdecoded],
+                ],
+            ],
+            'png src and gif url' => [
+                'input' => "<img src='{$pnguri}'><style>body { background-image: url('{$gifuri}'); }</style>",
+                'expected' => [
+                    (object) ['uri' => $pnguri, 'decoded' => $pngdecoded],
+                    (object) ['uri' => $gifuri, 'decoded' => $gifdecoded],
+                ],
             ],
         ];
     }


### PR DESCRIPTION
# Summary
The current regex for finding base64 src attributes does not handle certain formats, such as caps and encoded data broken up by whitespace.

This PR fixes that and adds unit tests.

# Testing
If you already have some records that refuse to migrate despite the migrate button appearing in `/admin/tool/encoded/index.php`, this patch should fix that.

Otherwise, please review and run the tests.