### PR TITLE
Add more mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ contain base64 encoded data and then automated the fixing of this data back into
 This tool will detect base64 data in all tables, but at this time view and migrate support has only been implemented for a few specific tables/columns. To add a new table:
 1. Add mapping to the get_all_mapping function in the helper class. The mapping should include the table name, column name, and the file info that corresponds to where a file uploaded in the GUI would be stored in mdl_files. You can get these values by saving a file in the GUI.
    * The view link in the mapping should lead to the page where the text field can be edited in the GUI. This is highly recommended as saving over an item in the GUI will usually convert the base64 data to a pluginfile without requiring a migration (aside from questions where versioning is involved).
-2. Migrations also require the instance id, which is the id of the context i.e. CONTEXT_COURSE uses course id and CONTEXT_MODULE uses module id. If a module id can be found in the same table you can specify a 'simplejoin' with the field name in the mapping, otherwise specific handling will need to be added to the helper functions in get_instance_id().
+2. Migrations also require the instance id, which is the id of the context i.e. CONTEXT_COURSE uses course id and CONTEXT_MODULE uses coursemodule id. If the module instance can be found in the same table you can specify a 'simplelookup' with the field name in the mapping, otherwise specific handling will need to be added to the helper functions in get_instance_id().
 
 ## GDPR
 This plugin is GDPR-compliant as it only stores the reference to records and does not restore user data.

--- a/classes/check/base64check.php
+++ b/classes/check/base64check.php
@@ -29,7 +29,6 @@ use tool_encoded\output\summary;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class base64check extends check {
-
     /** @var int Threshold total size in bytes after which should warn about base64 data **/
     public const WARNTHRESHOLD = 10 * 1024 * 1024;
 

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -182,7 +182,7 @@ class helper {
      * @param \stdClass $record
      * @return mixed
      */
-    public static function get_question_context(\stdClass $record): mixed {
+    public static function get_question_context(\stdClass $record) {
         global $DB;
 
         // Manually get context to avoid loading the question.

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -220,6 +220,13 @@ class helper {
         if (isset($mapping['simplelookup'])) {
             // If the instance id is in the same table we can get this with a simple lookup.
             $moduleinstance = $DB->get_field($table, $mapping['simplelookup'], ['id' => $record->native_id]);
+        } else if ($table === 'forum_posts') {
+            $sql = "SELECT d.forum
+                      FROM {forum_posts} p
+                      JOIN {forum_discussions} d ON d.id = p.discussion
+                     WHERE p.id = :postid";
+            $params = ['postid' => $record->native_id];
+            $moduleinstance = $DB->get_field_sql($sql, $params);
         }
 
         if (!empty($moduleinstance)) {
@@ -339,6 +346,15 @@ class helper {
                     'itemid' => '{$id}',
                     'view' => '/mod/lesson/editpage.php?id={$cmid}&pageid={$id}&edit=1',
                     'simplelookup' => 'lessonid',
+                ],
+            ],
+            'forum_posts' => [
+                'message' => [
+                    'component' => 'mod_forum',
+                    'filearea' => 'post',
+                    'context' => CONTEXT_MODULE,
+                    'itemid' => '{$id}',
+                    'view' => '/mod/forum/post.php?edit={$id}',
                 ],
             ],
         ];

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -417,7 +417,7 @@ class helper {
                     'filearea' => 'subquestion',
                     'context' => self::CONTEXT_QUESTION,
                     'itemid' => '{$id}',
-                    'view' => '',
+                    'view' => '/question/bank/editquestion/question.php?courseid={$courseid}&id={$questionid}',
                 ],
             ],
             'qtype_ddmatch_subquestions' => [
@@ -426,14 +426,14 @@ class helper {
                     'filearea' => 'subanswer',
                     'context' => self::CONTEXT_QUESTION,
                     'itemid' => '{$id}',
-                    'view' => '',
+                    'view' => '/question/bank/editquestion/question.php?courseid={$courseid}&id={$questionid}',
                 ],
                 'questiontext' => [
                     'component' => 'qtype_ddmatch',
                     'filearea' => 'subquestion',
                     'context' => self::CONTEXT_QUESTION,
                     'itemid' => '{$id}',
-                    'view' => '',
+                    'view' => '/question/bank/editquestion/question.php?courseid={$courseid}&id={$questionid}',
                 ],
             ],
             'qtype_essay_options' => [

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -357,6 +357,15 @@ class helper {
                     'view' => '/mod/forum/post.php?edit={$id}',
                 ],
             ],
+            'page' => [
+                'content' => [
+                    'component' => 'mod_page',
+                    'filearea' => 'content',
+                    'context' => CONTEXT_MODULE,
+                    'itemid' => 0,
+                    'view' => '/course/modedit.php?update={$cmid}',
+                ],
+            ],
         ];
     }
 }

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -107,7 +107,7 @@ class helper {
 
         switch(self::get_contextlevel($record, $mapping)) {
             case CONTEXT_MODULE:
-                return self::get_module_id($record, $mapping);
+                return self::get_coursemodule_id($record, $mapping);
             case CONTEXT_COURSE:
                 return self::get_course_id($record, $mapping);
             // TODO: Implement remaining contexts.
@@ -200,13 +200,13 @@ class helper {
     }
 
     /**
-     * Attempts to get the module id for some module subtables.
+     * Attempts to get the coursemodule id.
      *
      * @param \stdClass $record
      * @param array $mapping
      * @return int
      */
-    private static function get_module_id(\stdClass $record, array $mapping): int {
+    private static function get_coursemodule_id(\stdClass $record, array $mapping): int {
         global $DB;
 
         $modulename = str_replace('mod_', '', $mapping['component']);
@@ -215,21 +215,15 @@ class helper {
             return 0;
         }
 
+        // To get the coursemodule id, we need the module instance id.
         $table = $record->report_table;
-        $modulecols = array_keys($DB->get_columns($modulename));
-        if (!empty($simplejoin = $mapping['simplejoin']) && in_array('course', $modulecols)) {
-            $sql = "SELECT
-                        cm.id
-                    FROM
-                        {{$table}} t
-                    JOIN {{$modulename}} m ON m.id = t.{$simplejoin}
-                    JOIN {course_modules} cm ON cm.course = m.course AND cm.instance = m.id AND cm.module = :moduleid
-                    WHERE t.id = :nativeid";
-            $params = [
-                'moduleid' => $module->id,
-                'nativeid' => $record->native_id,
-            ];
-            return $DB->get_record_sql($sql, $params)->id ?? 0;
+        if (isset($mapping['simplelookup'])) {
+            // If the instance id is in the same table we can get this with a simple lookup.
+            $moduleinstance = $DB->get_field($table, $mapping['simplelookup'], ['id' => $record->native_id]);
+        }
+
+        if (!empty($moduleinstance)) {
+            return get_coursemodule_from_instance($modulename, $moduleinstance)->id ?? 0;
         }
         return 0;
     }
@@ -334,7 +328,7 @@ class helper {
                     'context' => CONTEXT_MODULE,
                     'itemid' => '{$id}',
                     'view' => '/mod/book/edit.php?cmid={$cmid}&id={$id}',
-                    'simplejoin' => 'bookid',
+                    'simplelookup' => 'bookid',
                 ],
             ],
             'lesson_pages' => [
@@ -344,7 +338,7 @@ class helper {
                     'context' => CONTEXT_MODULE,
                     'itemid' => '{$id}',
                     'view' => '/mod/lesson/editpage.php?id={$cmid}&pageid={$id}&edit=1',
-                    'simplejoin' => 'lessonid',
+                    'simplelookup' => 'lessonid',
                 ],
             ],
         ];

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -326,7 +326,7 @@ class helper {
         $text = str_replace('{$id}', $record->native_id, $text);
         $text = str_replace('{$cmid}', $record->instance_id, $text);
 
-        $courseid = $contextlevel == CONTEXT_COURSE ? $record->instance_id : 1;
+        $courseid = $contextlevel == CONTEXT_COURSE ? $record->instance_id : SITEID;
         $text = str_replace('{$courseid}', $courseid, $text);
 
         // Some may require DB calls. TODO: Look into storing other ids in the record.

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -261,7 +261,7 @@ class helper {
     private static function get_coursemodule_id(\stdClass $record, array $mapping): int {
         global $DB;
 
-        $modulename = str_replace('mod_', '', $mapping['component']);
+        $modulename = $mapping['modulename'] ?? str_replace('mod_', '', $mapping['component']);
         $module = $DB->get_record('modules', ['name' => $modulename]);
         if (!isset($module)) {
             return 0;
@@ -305,13 +305,33 @@ class helper {
             return '';
         }
 
-        // Add in proper ids.
-        $link = str_replace('{$id}', $record->native_id, $link);
-        $link = str_replace('{$cmid}', $record->instance_id, $link);
+        return self::resolve_placeholder_ids($record, $link, $contextlevel);
+    }
+
+    /**
+     * Resolves placeholder IDs.
+     *
+     * @param \stdClass $record
+     * @param string $text text to resolve
+     * @param string $contextlevel
+     * @return string
+     */
+    public static function resolve_placeholder_ids(\stdClass $record, string $text, string $contextlevel): string {
+        global $DB;
+
+        $text = str_replace('{$id}', $record->native_id, $text);
+        $text = str_replace('{$cmid}', $record->instance_id, $text);
 
         $courseid = $contextlevel == CONTEXT_COURSE ? $record->instance_id : 1;
-        $link = str_replace('{$courseid}', $courseid, $link);
-        return $link;
+        $text = str_replace('{$courseid}', $courseid, $text);
+
+        // Some may require DB calls. TODO: Look into storing other ids in the record.
+        if (strpos($text, '{$assigngradeid}') !== false) {
+            if ($assigngradeid = $DB->get_field($record->report_table, 'grade', ['id' => $record->native_id])) {
+                $text = str_replace('{$assigngradeid}', $assigngradeid, $text);
+            }
+        }
+        return $text;
     }
 
     /**
@@ -450,6 +470,18 @@ class helper {
                     'context' => self::CONTEXT_GRADE,
                     'itemid' => '{$id}',
                     'view' => '',
+                ],
+            ],
+            'assignfeedback_comments' => [
+                'commenttext' => [
+                    'component' => 'assignfeedback_comments',
+                    'filearea' => 'feedback',
+                    'context' => CONTEXT_MODULE,
+                    'itemid' => '{$assigngradeid}',
+                    'view' => '/mod/assign/view.php?id={$cmid}&gid={$assigngradeid}&plugin=comments' .
+                        '&action=viewpluginassignfeedback&returnaction=grading&returnparams',
+                    'simplelookup' => 'assignment',
+                    'modulename' => 'assign',
                 ],
             ],
         ];

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -32,6 +32,9 @@ class helper {
     /** @var string Context used for questions in mapping because it is variable */
     public const CONTEXT_QUESTION = 'question';
 
+    /** @var string Context used for grades in mapping because it is variable */
+    public const CONTEXT_GRADE = 'grade';
+
     /** @var array Preferred extensions to use for mimetypes */
     public const PREFERRED_EXTENSIONS = [
         'image/jpeg'        => 'jpg',
@@ -101,8 +104,9 @@ class helper {
             return 0;
         }
 
-        if (isset($mapping['context']) && $mapping['context'] === self::CONTEXT_QUESTION) {
-            return self::get_question_context($record)->instanceid ?? 0;
+        $variablecontext = self::get_variable_context($record, $mapping);
+        if (isset($variablecontext)) {
+            return $variablecontext->instanceid ?? 0;
         }
 
         switch(self::get_contextlevel($record, $mapping)) {
@@ -130,11 +134,44 @@ class helper {
             return null;
         }
 
-        if ($mapping['context'] === self::CONTEXT_QUESTION) {
-            return self::get_question_context($record, true)->contextlevel ?? null;
+        $variablecontext = self::get_variable_context($record, $mapping, true);
+        if (isset($variablecontext)) {
+            return $variablecontext->contextlevel ?? null;
         }
 
         return $mapping['context'];
+    }
+
+
+    /**
+     * Gets context for a record that can be variable
+     *
+     * @param \stdClass $record
+     * @param array $mapping
+     * @param bool $addtorecord store the context in the record
+     * @return mixed
+     */
+    public static function get_variable_context(\stdClass $record, array $mapping, bool $addtorecord = false) {
+        if (isset($record->context)) {
+            return $record->context;
+        }
+
+        switch($mapping['context'] ?? null) {
+            case self::CONTEXT_QUESTION:
+                $context = self::get_question_context($record);
+                break;
+            case self::CONTEXT_GRADE:
+                $context = self::get_grade_context($record);
+                break;
+            default:
+                return null;
+        }
+
+        if (!empty($context) && $addtorecord) {
+            $record->context = $context;
+        }
+
+        return $context;
     }
 
 
@@ -143,15 +180,10 @@ class helper {
      * This is variable and based upon the question category
      *
      * @param \stdClass $record
-     * @param bool $addtorecord store the context in the record
      * @return mixed
      */
-    public static function get_question_context(\stdClass $record, bool $addtorecord = false) {
+    public static function get_question_context(\stdClass $record): mixed {
         global $DB;
-
-        if (isset($record->context)) {
-            return $record->context;
-        }
 
         $joins = "JOIN {question_versions} qv ON q.id = qv.questionid
             JOIN {question_bank_entries} qbe ON qbe.id = qv.questionbankentryid
@@ -168,12 +200,27 @@ class helper {
         }
 
         $sql = "SELECT c.* FROM {question} q $joins WHERE $where";
-        $context = $DB->get_record_sql($sql, $params);
-        if ($addtorecord && !empty($context)) {
-            $record->context = $context;
+        return $DB->get_record_sql($sql, $params);
+    }
+
+    /**
+     * Gets the context of a grade
+     * This is variable and based upon the grade item
+     *
+     * @param \stdClass $record
+     * @return mixed
+     */
+    public static function get_grade_context(\stdClass $record) {
+        global $CFG, $DB;
+        require_once($CFG->libdir.'/gradelib.php');
+
+        $itemid = $DB->get_field($record->report_table, 'itemid', ['id' => $record->native_id]);
+        if (empty($itemid)) {
+            return false;
         }
 
-        return $context;
+        $grade = new \grade_grade(['itemid' => $itemid], false);
+        return $grade->get_context();
     }
 
     /**
@@ -364,6 +411,24 @@ class helper {
                     'context' => CONTEXT_MODULE,
                     'itemid' => 0,
                     'view' => '/course/modedit.php?update={$cmid}',
+                ],
+            ],
+            'grade_grades' => [
+                'feedback' => [
+                    'component' => 'grade',
+                    'filearea' => 'feedback',
+                    'context' => self::CONTEXT_GRADE,
+                    'itemid' => '{$id}',
+                    'view' => '',
+                ],
+            ],
+            'grade_grades_history' => [
+                'feedback' => [
+                    'component' => 'grade',
+                    'filearea' => 'historyfeedback',
+                    'context' => self::CONTEXT_GRADE,
+                    'itemid' => '{$id}',
+                    'view' => '',
                 ],
             ],
         ];

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -185,18 +185,23 @@ class helper {
     public static function get_question_context(\stdClass $record): mixed {
         global $DB;
 
+        // Manually get context to avoid loading the question.
         $joins = "JOIN {question_versions} qv ON q.id = qv.questionid
             JOIN {question_bank_entries} qbe ON qbe.id = qv.questionbankentryid
             JOIN {question_categories} qc ON qc.id = qbe.questioncategoryid
             JOIN {context} c ON c.id = qc.contextid";
 
-        if ($record->report_table === 'question') {
+        $table = $record->report_table;
+        if ($table === 'question') {
             $where = "q.id = :questionid";
             $params = ['questionid' => $record->native_id];
-        } else if ($record->report_table === 'qtype_match_subquestions') {
-            $joins .= " JOIN {qtype_match_subquestions} subq ON subq.questionid = q.id";
+        } else if (strpos($table, 'qtype_') === 0) {
+            // All tables starting with qtype should contain questionid.
+            $joins .= " JOIN {{$table}} subq ON subq.questionid = q.id";
             $where = "subq.id = :subqid";
             $params = ['subqid' => $record->native_id];
+        } else {
+            return false;
         }
 
         $sql = "SELECT c.* FROM {question} q $joins WHERE $where";
@@ -360,6 +365,22 @@ class helper {
             'qtype_match_subquestions' => [
                 'questiontext' => [
                     'component' => 'qtype_match',
+                    'filearea' => 'subquestion',
+                    'context' => self::CONTEXT_QUESTION,
+                    'itemid' => '{$id}',
+                    'view' => '',
+                ],
+            ],
+            'qtype_ddmatch_subquestions' => [
+                'answertext' => [
+                    'component' => 'qtype_ddmatch',
+                    'filearea' => 'subanswer',
+                    'context' => self::CONTEXT_QUESTION,
+                    'itemid' => '{$id}',
+                    'view' => '',
+                ],
+                'questiontext' => [
+                    'component' => 'qtype_ddmatch',
                     'filearea' => 'subquestion',
                     'context' => self::CONTEXT_QUESTION,
                     'itemid' => '{$id}',

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -195,6 +195,10 @@ class helper {
         if ($table === 'question') {
             $where = "q.id = :questionid";
             $params = ['questionid' => $record->native_id];
+        } else if ($table === 'question_answers') {
+            $joins .= " JOIN {{$table}} qa ON qa.question = q.id";
+            $where = "qa.id = :questionanswerid";
+            $params = ['questionanswerid' => $record->native_id];
         } else if (strpos($table, 'qtype_') === 0) {
             // All tables starting with qtype should contain questionid.
             $joins .= " JOIN {{$table}} subq ON subq.questionid = q.id";
@@ -334,6 +338,11 @@ class helper {
             if ($assignsubmissionid = $DB->get_field($record->report_table, 'submission', ['id' => $record->native_id])) {
                 $text = str_replace('{$assignsubmissionid}', $assignsubmissionid, $text);
             }
+        } else if (strpos($text, '{$questionid') !== false) {
+            $columnname = $record->report_table === 'question_answers' ? 'question' : 'questionid';
+            if ($questionid = $DB->get_field($record->report_table, $columnname, ['id' => $record->native_id])) {
+                $text = str_replace('{$questionid}', $questionid, $text);
+            }
         }
         return $text;
     }
@@ -384,6 +393,22 @@ class helper {
                     'context' => self::CONTEXT_QUESTION,
                     'itemid' => '{$id}',
                     'view' => '/question/bank/editquestion/question.php?courseid={$courseid}&id={$id}',
+                ],
+            ],
+            'question_answers' => [
+                'answer' => [
+                    'component' => 'question',
+                    'filearea' => 'answer',
+                    'context' => self::CONTEXT_QUESTION,
+                    'itemid' => '{$id}',
+                    'view' => '/question/bank/editquestion/question.php?courseid={$courseid}&id={$questionid}',
+                ],
+                'feedback' => [
+                    'component' => 'question',
+                    'filearea' => 'answerfeedback',
+                    'context' => self::CONTEXT_QUESTION,
+                    'itemid' => '{$id}',
+                    'view' => '/question/bank/editquestion/question.php?courseid={$courseid}&id={$questionid}',
                 ],
             ],
             'qtype_match_subquestions' => [

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -330,6 +330,10 @@ class helper {
             if ($assigngradeid = $DB->get_field($record->report_table, 'grade', ['id' => $record->native_id])) {
                 $text = str_replace('{$assigngradeid}', $assigngradeid, $text);
             }
+        } else if (strpos($text, '{$assignsubmissionid}') !== false) {
+            if ($assignsubmissionid = $DB->get_field($record->report_table, 'submission', ['id' => $record->native_id])) {
+                $text = str_replace('{$assignsubmissionid}', $assignsubmissionid, $text);
+            }
         }
         return $text;
     }
@@ -480,6 +484,18 @@ class helper {
                     'itemid' => '{$assigngradeid}',
                     'view' => '/mod/assign/view.php?id={$cmid}&gid={$assigngradeid}&plugin=comments' .
                         '&action=viewpluginassignfeedback&returnaction=grading&returnparams',
+                    'simplelookup' => 'assignment',
+                    'modulename' => 'assign',
+                ],
+            ],
+            'assignsubmission_onlinetext' => [
+                'onlinetext' => [
+                    'component' => 'assignsubmission_onlinetext',
+                    'filearea' => 'submissions_onlinetext',
+                    'context' => CONTEXT_MODULE,
+                    'itemid' => '{$assignsubmissionid}',
+                    'view' => '/mod/assign/view.php?id={$cmid}&sid={$assignsubmissionid}&plugin=onlinetext' .
+                        '&action=viewpluginassignsubmission&returnaction=grading&returnparams',
                     'simplelookup' => 'assignment',
                     'modulename' => 'assign',
                 ],

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -109,7 +109,7 @@ class helper {
             return $variablecontext->instanceid ?? 0;
         }
 
-        switch(self::get_contextlevel($record, $mapping)) {
+        switch (self::get_contextlevel($record, $mapping)) {
             case CONTEXT_MODULE:
                 return self::get_coursemodule_id($record, $mapping);
             case CONTEXT_COURSE:
@@ -156,7 +156,7 @@ class helper {
             return $record->context;
         }
 
-        switch($mapping['context'] ?? null) {
+        switch ($mapping['context'] ?? null) {
             case self::CONTEXT_QUESTION:
                 $context = self::get_question_context($record);
                 break;
@@ -221,7 +221,7 @@ class helper {
      */
     public static function get_grade_context(\stdClass $record) {
         global $CFG, $DB;
-        require_once($CFG->libdir.'/gradelib.php');
+        require_once($CFG->libdir . '/gradelib.php');
 
         $itemid = $DB->get_field($record->report_table, 'itemid', ['id' => $record->native_id]);
         if (empty($itemid)) {

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -436,6 +436,16 @@ class helper {
                     'view' => '',
                 ],
             ],
+            'qtype_essay_options' => [
+                'graderinfo' => [
+                    'component' => 'qtype_essay',
+                    'filearea' => 'graderinfo',
+                    'context' => self::CONTEXT_QUESTION,
+                    'itemid' => '{$id}',
+                    'view' => '/question/bank/editquestion/question.php?courseid={$courseid}&id={$questionid}',
+                ],
+                // The responsetemplate column doesn't allow pluginfiles so we can't store the data safely.
+            ],
             'course_sections' => [
                 'summary' => [
                     'component' => 'course',

--- a/classes/local/entities/records.php
+++ b/classes/local/entities/records.php
@@ -35,7 +35,6 @@ use tool_encoded\helper;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class records extends base {
-
     /**
      * Database tables that this entity uses and their default aliases
      *
@@ -143,7 +142,7 @@ class records extends base {
             ->add_field("{$tablealias}.encoded_size")
             ->set_is_sortable(true)
             ->set_disabled_aggregation(['avg', 'count', 'countdistinct', 'max', 'min', 'sum'])
-            ->add_callback(static function(int $value): string {
+            ->add_callback(static function (int $value): string {
                 // Return the bytes as kilobytes.
                 return new lang_string('size', 'tool_encoded', number_format($value / 1024, 2));
             });
@@ -158,7 +157,7 @@ class records extends base {
             ->set_type(column::TYPE_BOOLEAN)
             ->add_field("{$tablealias}.migrated")
             ->set_is_sortable(true)
-            ->add_callback(static function(bool $value): string {
+            ->add_callback(static function (bool $value): string {
                 return format::boolean_as_text($value);
             });
 
@@ -208,7 +207,7 @@ class records extends base {
                 {$tablealias}.instance_id, {$tablealias}.migrated")
             ->set_is_sortable(false)
             ->set_disabled_aggregation(['avg', 'count', 'countdistinct', 'max', 'min', 'sum'])
-            ->add_callback(static function(string $value, \stdClass $row): string {
+            ->add_callback(static function (string $value, \stdClass $row): string {
                 global $OUTPUT;
 
                 $buttons = '';
@@ -216,16 +215,23 @@ class records extends base {
                 // Add migrate button.
                 if (helper::can_migrate($row)) {
                     $migrateparams = ['action' => 'migrate', 'recordid' => $row->id, 'sesskey' => sesskey()];
-                    $migratebutton = new \single_button(new \moodle_url('/admin/tool/encoded/index.php', $migrateparams),
-                        get_string('migrate', 'tool_encoded'), 'post', helper::get_button_type());
+                    $migratebutton = new \single_button(
+                        new \moodle_url('/admin/tool/encoded/index.php', $migrateparams),
+                        get_string('migrate', 'tool_encoded'),
+                        'post',
+                        helper::get_button_type()
+                    );
                     $migratebutton->add_confirm_action(get_string('confirmmigrateid', 'tool_encoded', $row->id));
                     $buttons .= $OUTPUT->render($migratebutton);
                 }
 
                 // Add view button.
                 if ($view = helper::format_view_link($row)) {
-                    $buttons .= \html_writer::link(new \moodle_url($view),
-                        get_string('view'), ['class' => 'btn btn-secondary btn-sm mx-1']);
+                    $buttons .= \html_writer::link(
+                        new \moodle_url($view),
+                        get_string('view'),
+                        ['class' => 'btn btn-secondary btn-sm mx-1']
+                    );
                 }
 
                 return $buttons;
@@ -249,7 +255,7 @@ class records extends base {
             "{$tablealias}.report_table"
         ))
             ->add_joins($this->get_joins())
-            ->set_options_callback(static function(): array {
+            ->set_options_callback(static function (): array {
                 global $DB;
                 $tables = $DB->get_fieldset_sql(
                     'SELECT DISTINCT report_table FROM {tool_encoded_base64_records} ORDER BY report_table ASC'
@@ -270,7 +276,7 @@ class records extends base {
             "{$tablealias}.report_column"
         ))
             ->add_joins($this->get_joins())
-            ->set_options_callback(static function(): array {
+            ->set_options_callback(static function (): array {
                 global $DB;
                 $cols = $DB->get_fieldset_sql(
                     'SELECT DISTINCT report_column FROM {tool_encoded_base64_records} ORDER BY report_column ASC'
@@ -291,7 +297,7 @@ class records extends base {
             "{$tablealias}.mimetype"
         ))
             ->add_joins($this->get_joins())
-            ->set_options_callback(static function(): array {
+            ->set_options_callback(static function (): array {
                 global $DB;
                 $mimes = $DB->get_fieldset_sql(
                     'SELECT DISTINCT mimetype FROM {tool_encoded_base64_records} ORDER BY mimetype ASC'

--- a/classes/local/systemreports/records.php
+++ b/classes/local/systemreports/records.php
@@ -118,25 +118,32 @@ class records extends system_report {
         if ($unmigrated) {
             $migratebutton = new \single_button(
                 new \moodle_url('/admin/tool/encoded/index.php', ['action' => 'migrate', 'sesskey' => sesskey()]),
-                get_string('queueallrecords', 'tool_encoded'), 'post', helper::get_button_type());
+                get_string('queueallrecords', 'tool_encoded'),
+                'post',
+                helper::get_button_type()
+            );
             $migratebutton->add_confirm_action(get_string('confirmmigrate', 'tool_encoded'));
             $buttons .= $OUTPUT->render($migratebutton);
         }
 
         // Add link to generate page.
-        $buttons .= \html_writer::link(new \moodle_url('/admin/tool/encoded/generate.php'),
-            get_string('generatereport', 'tool_encoded'), ['class' => 'btn btn-secondary m-1']);
+        $buttons .= \html_writer::link(
+            new \moodle_url('/admin/tool/encoded/generate.php'),
+            get_string('generatereport', 'tool_encoded'),
+            ['class' => 'btn btn-secondary m-1']
+        );
 
         // Add button to clear all records.
         if ($anyrecords) {
             $clearbutton = new \single_button(
                 new \moodle_url('/admin/tool/encoded/index.php', ['action' => 'clearrecords', 'sesskey' => sesskey()]),
-                get_string('clearrecords', 'tool_encoded'), 'post');
+                get_string('clearrecords', 'tool_encoded'),
+                'post'
+            );
             $clearbutton->add_confirm_action(get_string('confirmclear', 'tool_encoded'));
             $buttons .= $OUTPUT->render($clearbutton);
         }
 
         return $buttons;
     }
-
 }

--- a/classes/output/generate.php
+++ b/classes/output/generate.php
@@ -27,7 +27,6 @@ use tool_encoded\helper;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class generate extends \flexible_table {
-
     /**
      * @var array table info and summary
      */
@@ -268,7 +267,7 @@ class generate extends \flexible_table {
      */
     public function sort_data() {
         $sortcols = $this->get_sort_columns();
-        usort($this->tabledata, function($a, $b) use ($sortcols) {
+        usort($this->tabledata, function ($a, $b) use ($sortcols) {
             foreach ($sortcols as $col => $tdir) {
                 $cmp = $a->$col <=> $b->$col;
                 if ($cmp !== 0) {
@@ -292,13 +291,19 @@ class generate extends \flexible_table {
         // Add generate all button.
         $generateallbutton = new \single_button(
             new \moodle_url('/admin/tool/encoded/generate.php', ['table' => 'all', 'sesskey' => sesskey()]),
-            get_string('queuealltables', 'tool_encoded', count($this->tabledata)), 'post', helper::get_button_type());
+            get_string('queuealltables', 'tool_encoded', count($this->tabledata)),
+            'post',
+            helper::get_button_type()
+        );
         $generateallbutton->add_confirm_action(get_string('confirmgenerate', 'tool_encoded'));
         $buttons .= $OUTPUT->render($generateallbutton);
 
         // Add link to report page.
-        $buttons .= \html_writer::link(new \moodle_url('/admin/tool/encoded/index.php'),
-            get_string('viewreport', 'tool_encoded'), ['class' => 'btn btn-secondary m-1']);
+        $buttons .= \html_writer::link(
+            new \moodle_url('/admin/tool/encoded/index.php'),
+            get_string('viewreport', 'tool_encoded'),
+            ['class' => 'btn btn-secondary m-1']
+        );
 
         return $buttons;
     }

--- a/classes/output/generate.php
+++ b/classes/output/generate.php
@@ -121,17 +121,7 @@ class generate extends \flexible_table {
         // Cached fetch.
         $tables = $DB->get_tables();
         foreach ($tables as $table) {
-            $tablecols = $DB->get_columns($table);
-            $potentialcols = [];
-            foreach ($tablecols as $column) {
-                // Only convert columns that are either text or long varchar.
-                if ($column->meta_type == 'X' || ($column->meta_type == 'C' && $column->max_length > 255)) {
-                    // We only want fields that have an associated format col as they are editable by the user.
-                    if (array_key_exists($column->name . 'format', $tablecols)) {
-                        $potentialcols[] = $column->name;
-                    }
-                }
-            }
+            $potentialcols = self::get_editor_columns($table);
 
             // Add tables with potential columns to the report.
             if (!empty($potentialcols)) {
@@ -151,6 +141,39 @@ class generate extends \flexible_table {
             }
         }
         ksort($this->tabledata);
+    }
+
+    /**
+     * Gets columns that contain user editable text.
+     *
+     * @param string $table
+     * @return array column names
+     */
+    public static function get_editor_columns(string $table): array {
+        global $DB;
+
+        // Some editor columns don't have an exact match for the 'format' column and need to be hardcoded.
+        $includecolumns = [
+            'assignfeedback_comments' => [
+                'commenttext' => 'commentformat',
+            ],
+            'assignsubmission_onlinetext' => [
+                'onlinetext' => 'onlineformat',
+            ],
+        ];
+
+        $editorcolumns = [];
+        $tablecols = $DB->get_columns($table);
+        foreach ($tablecols as $column) {
+            // Only convert columns that are either text or long varchar.
+            if ($column->meta_type == 'X' || ($column->meta_type == 'C' && $column->max_length > 255)) {
+                // We only want fields that have an associated format col as they are editable by the user.
+                if (array_key_exists($column->name . 'format', $tablecols) || isset($includecolumns[$table][$column->name])) {
+                    $editorcolumns[] = $column->name;
+                }
+            }
+        }
+        return $editorcolumns;
     }
 
     /**

--- a/classes/output/summary.php
+++ b/classes/output/summary.php
@@ -25,7 +25,6 @@ namespace tool_encoded\output;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class summary extends \table_sql {
-
     /**
      * Constructor.
      */

--- a/classes/task/generate_report.php
+++ b/classes/task/generate_report.php
@@ -23,6 +23,7 @@ require_once($CFG->dirroot . '/course/lib.php');
 use core\task\adhoc_task;
 use core\task\manager;
 use tool_encoded\helper;
+use tool_encoded\output\generate;
 
 /**
  * Given some columns to migrate, this task will generate a report of potential bad data.
@@ -221,17 +222,7 @@ class generate_report extends adhoc_task {
         // Cached fetch.
         $tables = $DB->get_tables();
         foreach ($tables as $table) {
-            $tablecols = $DB->get_columns($table);
-            $allcols = [];
-            foreach ($tablecols as $column) {
-                // Only convert columns that are either text or long varchar.
-                if ($column->meta_type == 'X' || ($column->meta_type == 'C' && $column->max_length > 255)) {
-                    // We only want fields that have an associated format col as they are editable by the user.
-                    if (array_key_exists($column->name . 'format', $tablecols)) {
-                        $allcols[] = $column->name;
-                    }
-                }
-            }
+            $allcols = generate::get_editor_columns($table);
             if (!empty($allcols)) {
                 $cols = implode(',', $allcols);
                 self::queue($table, $cols);

--- a/classes/task/migrate.php
+++ b/classes/task/migrate.php
@@ -182,10 +182,10 @@ class migrate extends adhoc_task {
 
         switch(helper::get_contextlevel($record, $mapping)) {
             case CONTEXT_MODULE:
-                $context = \context_module::instance($record->instance_id);
+                $context = \context_module::instance($record->instance_id, IGNORE_MISSING);
                 break;
             case CONTEXT_COURSE:
-                $context = \context_course::instance($record->instance_id);
+                $context = \context_course::instance($record->instance_id, IGNORE_MISSING);
                 break;
             // TODO: Implement remaining contexts.
             case CONTEXT_USER:
@@ -194,7 +194,8 @@ class migrate extends adhoc_task {
                 $context = $record->context ?? null;
         }
 
-        if (!isset($context)) {
+        // Skip processing of records with missing context.
+        if (!isset($context) || $context === false) {
             return '';
         }
 

--- a/classes/task/migrate.php
+++ b/classes/task/migrate.php
@@ -180,7 +180,7 @@ class migrate extends adhoc_task {
             return '';
         }
 
-        switch(helper::get_contextlevel($record, $mapping)) {
+        switch (helper::get_contextlevel($record, $mapping)) {
             case CONTEXT_MODULE:
                 $context = \context_module::instance($record->instance_id, IGNORE_MISSING);
                 break;

--- a/classes/task/migrate.php
+++ b/classes/task/migrate.php
@@ -207,7 +207,7 @@ class migrate extends adhoc_task {
             'contextid' => $context->id,
             'component' => $mapping['component'],
             'filearea' => $mapping['filearea'],
-            'itemid' => str_replace('{$id}', $record->native_id, $mapping['itemid']),
+            'itemid' => helper::resolve_placeholder_ids($record, $mapping['itemid'], $context->contextlevel ?? ''),
             'filepath' => '/',
             'filename' => $basename . '_' . uniqid() . $extension,
             'source' => 'tool_encoded',

--- a/classes/task/queue_base64_report.php
+++ b/classes/task/queue_base64_report.php
@@ -25,7 +25,6 @@ namespace tool_encoded\task;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class queue_base64_report extends \core\task\scheduled_task {
-
     /**
      * Get task name
      */

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -34,7 +34,6 @@ function xmldb_tool_encoded_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2025062600) {
-
         // Changing type of field report_table on table tool_encoded_base64_tables to char.
         $table = new xmldb_table('tool_encoded_base64_tables');
         $field = new xmldb_field('report_table', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null, 'id');

--- a/lang/en/tool_encoded.php
+++ b/lang/en/tool_encoded.php
@@ -22,18 +22,18 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 // Plugin strings.
+$string['checkbase64check'] = 'Base64 data';
+$string['checkbase64column'] = 'The \'{$a->column}\' column of the \'{$a->table}\' table contains {$a->size} of base64-encoded data across {$a->records} records';
+$string['checkbase64info'] = 'The database contains {$a->size} of base64-encoded data across {$a->columns} columns and {$a->records} records';
+$string['checkbase64ok'] = 'No base64 data over the minimum threshold of {$a} was detected';
+$string['displayreport'] = 'Display report';
+$string['generatereport'] = 'Generate report';
 $string['pluginname'] = 'Base64 Encoder';
 $string['privacy:metadata'] = 'The Site admin presets tool does not store any personal data.';
-$string['generatereport'] = 'Generate report';
-$string['displayreport'] = 'Display report';
-$string['viewreport'] = 'View report';
 $string['queuereport'] = 'Queue base64-encoded data report generation';
-$string['checkbase64check'] = 'Base64 data';
-$string['checkbase64ok'] = 'No base64 data over the minimum threshold of {$a} was detected';
-$string['checkbase64info'] = 'The database contains {$a->size} of base64-encoded data across {$a->columns} columns and {$a->records} records';
-$string['checkbase64column'] = 'The \'{$a->column}\' column of the \'{$a->table}\' table contains {$a->size} of base64-encoded data across {$a->records} records';
 $string['sizesetting'] = 'Size setting';
 $string['sizesettingdesc'] = 'The size in kilobytes to flag in the generated report.';
+$string['viewreport'] = 'View report';
 
 // Generate page strings.
 $string['generate'] = 'Generate';

--- a/tests/local/entities/records_test.php
+++ b/tests/local/entities/records_test.php
@@ -31,7 +31,7 @@ defined('MOODLE_INTERNAL') || die();
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @covers    \tool_encoded\local\entities\records
  */
-class records_test extends \advanced_testcase {
+final class records_test extends \advanced_testcase {
     /**
      * Tests the entities records
      *

--- a/tests/local/systemreports/records_test.php
+++ b/tests/local/systemreports/records_test.php
@@ -30,7 +30,7 @@ defined('MOODLE_INTERNAL') || die();
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @covers    \tool_encoded\local\systemreports\records
  */
-class records_test extends \advanced_testcase {
+final class records_test extends \advanced_testcase {
     public function test_records(): void {
         global $DB;
         $this->resetAfterTest();

--- a/tests/task/generate_report_test.php
+++ b/tests/task/generate_report_test.php
@@ -28,7 +28,7 @@ defined('MOODLE_INTERNAL') || die();
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @covers    \tool_encoded\task\generate_report
  */
-class generate_report_test extends \advanced_testcase {
+final class generate_report_test extends \advanced_testcase {
     /**
      * Confirm the task is created and executed.
      *
@@ -38,7 +38,7 @@ class generate_report_test extends \advanced_testcase {
      * @param array $records The expected records.
      * @return void
      */
-    public function test_task($table,  $columns,  $records): void {
+    public function test_task($table, $columns, $records): void {
         global $DB;
         $this->resetAfterTest();
         // Disable size filter for tests as examples are under the default size.

--- a/tests/task/helper_test.php
+++ b/tests/task/helper_test.php
@@ -25,7 +25,7 @@ namespace tool_encoded;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @coversDefaultClass \tool_encoded\helper
  */
-class helper_test extends \advanced_testcase {
+final class helper_test extends \advanced_testcase {
     /**
      * Set up before each test.
      */

--- a/tests/task/helper_test.php
+++ b/tests/task/helper_test.php
@@ -1,0 +1,186 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_encoded;
+
+/**
+ * Helper unit tests.
+ *
+ * @package   tool_encoded
+ * @author    Benjamin Walker (benjaminwalker@catalyst-au.net)
+ * @copyright 2024 Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @coversDefaultClass \tool_encoded\helper
+ */
+class helper_test extends \advanced_testcase {
+    /**
+     * Set up before each test.
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+        $this->setAdminUser();
+    }
+
+    /**
+     * Tests getting instance id from a base64 record
+     *
+     * @covers ::get_instance_id
+     */
+    public function test_get_instance_id(): void {
+        $course = $this->getDataGenerator()->create_course();
+        $user = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+
+        // Test course mapping.
+        $section = course_create_section($course);
+        $record = (object) [
+            'report_table' => 'course_sections',
+            'report_column' => 'summary',
+            'native_id' => $section->id,
+        ];
+        $instanceid = helper::get_instance_id($record);
+        $this->assertEquals($course->id, $instanceid);
+
+        // Logic for direct module tables like 'page' load the cmid directly and should not use the helper.
+
+        // Test course module mapping with simple lookups.
+        $book = $this->getDataGenerator()->create_module('book', ['course' => $course->id]);
+        $bookgenerator = $this->getDataGenerator()->get_plugin_generator('mod_book');
+        $chapter = $bookgenerator->create_chapter(['bookid' => $book->id]);
+
+        $record = (object) [
+            'report_table' => 'book_chapters',
+            'report_column' => 'content',
+            'native_id' => $chapter->id,
+        ];
+        $instanceid = helper::get_instance_id($record);
+        $this->assertEquals($book->cmid, $instanceid);
+
+        // Test course module mapping for forum posts.
+        $forum = $this->getDataGenerator()->create_module('forum', ['course' => $course->id]);
+        $forumgenerator = $this->getDataGenerator()->get_plugin_generator('mod_forum');
+        $properties = (object) [
+            'course' => $course->id,
+            'forum' => $forum->id,
+            'userid' => $user->id,
+        ];
+        $discussion = $forumgenerator->create_discussion($properties);
+        $properties->discussion = $discussion->id;
+        $post = $forumgenerator->create_post($properties);
+
+        $record = (object) [
+            'report_table' => 'forum_posts',
+            'report_column' => 'message',
+            'native_id' => $post->id,
+        ];
+        $instanceid = helper::get_instance_id($record);
+        $this->assertEquals($forum->cmid, $instanceid);
+    }
+
+    /**
+     * Tests getting variable context from a base64 record
+     *
+     * @covers ::get_variable_context
+     */
+    public function test_get_variable_context(): void {
+        global $DB;
+
+        $course = $this->getDataGenerator()->create_course();
+        $user = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+
+        // Test mapping of question table to system context.
+        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
+        $category = $questiongenerator->create_question_category();
+        $question = $questiongenerator->create_question('multichoice', null, ['category' => $category->id]);
+
+        $record = (object) [
+            'report_table' => 'question',
+            'report_column' => 'questiontext',
+            'native_id' => $question->id,
+        ];
+
+        $mapping = helper::get_mapping($record);
+        $context = helper::get_variable_context($record, $mapping);
+        $systemcontext = \context_system::instance();
+        $this->assertEquals($systemcontext->contextlevel, $context->contextlevel);
+        $this->assertEquals($systemcontext->instanceid, $context->instanceid);
+
+        // Test mapping of question table to course context.
+        $coursecontext = \context_course::instance($course->id);
+        $category = $questiongenerator->create_question_category(['contextid' => $coursecontext->id]);
+        $question = $questiongenerator->create_question('multichoice', null, ['category' => $category->id]);
+
+        $record = (object) [
+            'report_table' => 'question',
+            'report_column' => 'questiontext',
+            'native_id' => $question->id,
+        ];
+
+        $mapping = helper::get_mapping($record);
+        $context = helper::get_variable_context($record, $mapping);
+        $this->assertEquals($coursecontext->contextlevel, $context->contextlevel);
+        $this->assertEquals($coursecontext->instanceid, $context->instanceid);
+
+        // Test mapping of question type tables to course context.
+        $category = $questiongenerator->create_question_category(['contextid' => $coursecontext->id]);
+        $question = $questiongenerator->create_question('match', null, ['category' => $category->id]);
+
+        $subquestionid = $DB->get_field('qtype_match_subquestions', 'id', ['questionid' => $question->id], IGNORE_MULTIPLE);
+        $record = (object) [
+            'report_table' => 'qtype_match_subquestions',
+            'report_column' => 'questiontext',
+            'native_id' => $subquestionid,
+        ];
+
+        $mapping = helper::get_mapping($record);
+        $context = helper::get_variable_context($record, $mapping);
+        $this->assertEquals($coursecontext->contextlevel, $context->contextlevel);
+        $this->assertEquals($coursecontext->instanceid, $context->instanceid);
+
+        // Test mapping of grade grades to module context.
+        $assign = $this->getDataGenerator()->create_module('assign', [
+            'course' => $course->id,
+            'assignfeedback_comments_enabled' => 1,
+        ]);
+
+        $gradeitem = $this->getDataGenerator()->create_grade_item([
+            'courseid' => $course->id,
+            'itemtype' => 'mod',
+            'itemmodule' => 'assign',
+            'iteminstance' => $assign->id,
+        ]);
+
+        $gradegrade = $this->getDataGenerator()->create_grade_grade([
+            'itemid' => $gradeitem->id,
+            'userid' => $user->id,
+            'assignfeedbackcomments_editor' => ['text' => 'Comment', 'format' => FORMAT_MOODLE],
+        ]);
+
+        $record = (object) [
+            'report_table' => 'grade_grades',
+            'report_column' => 'feedback',
+            'native_id' => $gradegrade->id,
+        ];
+
+        $mapping = helper::get_mapping($record);
+        $context = helper::get_variable_context($record, $mapping);
+        $modulecontext = \context_module::instance($assign->cmid);
+        $this->assertEquals($modulecontext->contextlevel, $context->contextlevel);
+        $this->assertEquals($modulecontext->instanceid, $context->instanceid);
+    }
+}

--- a/tests/task/migrate_test.php
+++ b/tests/task/migrate_test.php
@@ -162,7 +162,7 @@ final class migrate_test extends advanced_testcase {
             'label',
             'mod_label',
             'columns' => [
-                'intro' => '<img alt="Test image" src="'. $source .'" />',
+                'intro' => '<img alt="Test image" src="' . $source . '" />',
             ],
         ];
 

--- a/version.php
+++ b/version.php
@@ -25,6 +25,6 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'tool_encoded';
-$plugin->version = 2025063001;
+$plugin->version = 20250100900;
 $plugin->requires = 2022112800;
 $plugin->supported = [401, 405];


### PR DESCRIPTION
Adds mapping for:

- page content
- forum_posts
- grade_grades
- grade_grades_history
- qtype_ddmatch_subquestions
- assignfeedback_comments
- assignsubmission_onlinetext
- question_answers
- qtype_essay_options

And some minor refactors for clarity, and hardcode 2 tables that have different 'format' column names.

Note that grade_grades takes content from many other sources (assign etc), so even if you fix the data there the base64 data may re-appear if the original field isn't fixed and is updated again.

For the view links:
- The actual content for grade_grades is not properly visible in an edit field to an admin (there is one place it appears, but it doesn't accept pluginfiles). It is usually modified in a plugin instead, which we can't link back to directly.
- grade_grades_history is not editable in the UI

It would be great if we could get some unit tests to cover mapping, but not sure if it's possible. It might be possible using some editor logic? 