### PR TITLE
Improve handling of missing grade items

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -228,8 +228,13 @@ class helper {
             return false;
         }
 
-        $grade = new \grade_grade(['itemid' => $itemid], false);
-        return $grade->get_context();
+        try {
+            $grade = new \grade_grade(['itemid' => $itemid], false);
+            return $grade->get_context();
+        } catch (\Throwable $e) {
+            // If the grade item no longer exists we can't get context from history alone.
+            return false;
+        }
     }
 
     /**

--- a/version.php
+++ b/version.php
@@ -25,6 +25,6 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'tool_encoded';
-$plugin->version = 20250100900;
+$plugin->version = 20250102400;
 $plugin->requires = 2022112800;
 $plugin->supported = [401, 405];


### PR DESCRIPTION
Resolves issue with missing grade items in generate_report task. These are likely common since history does include references to deleted grade items.

```
2025-10-24 12:41:06 Execute adhoc task: tool_encoded\task\generate_report
2025-10-24 12:41:06 Adhoc task id: 17811304
2025-10-24 12:41:06 Adhoc task custom data: {"table":"grade_grades_history","columns":"feedback,information"}
2025-10-24 12:41:06 ... started 12:41:06. Current memory use 4.0 MB.
2025-10-24 12:41:06 Debugging increased temporarily due to faildelay of 60
++ Missing grade item id 79471 ++
* line 286 of /lib/grade/grade_grade.php: call to debugging()
* line 1284 of /lib/grade/grade_grade.php: call to grade_grade->load_grade_item()
* line 232 of /admin/tool/encoded/classes/helper.php: call to grade_grade->get_context()
* line 164 of /admin/tool/encoded/classes/helper.php: call to tool_encoded\helper::get_grade_context()
* line 107 of /admin/tool/encoded/classes/helper.php: call to tool_encoded\helper::get_variable_context()
* line 190 of /admin/tool/encoded/classes/task/generate_report.php: call to tool_encoded\helper::get_instance_id()
* line 76 of /admin/tool/encoded/classes/task/generate_report.php: call to tool_encoded\task\generate_report->extend_records()
* line 519 of /lib/classes/cron.php: call to tool_encoded\task\generate_report->execute()
* line 302 of /lib/classes/cron.php: call to core\cron::run_inner_adhoc_task()
* line 174 of /admin/cli/adhoc_task.php: call to core\cron::run_adhoc_tasks()
2025-10-24 12:41:15 ... used 26 dbqueries
2025-10-24 12:41:15 ... used 8.8016541004181 seconds
2025-10-24 12:41:15 Adhoc task failed: tool_encoded\task\generate_report,Call to a member function get_context() on bool
2025-10-24 12:41:15 Backtrace:
10-24 12:41:15 * line 232 of /admin/tool/encoded/classes/helper.php: call to grade_grade->get_context()
```

The grade item is loaded inside $grade->get_context(), so all we can do is catch the runtime error. 

I couldn't find an easy way to get the context for these - I don't think we have enough information from the history alone, but if I'm wrong we can implement that in the future.