### PR TITLE
Issue #49: Require tablelib.php

### DIFF
--- a/classes/output/generate.php
+++ b/classes/output/generate.php
@@ -16,6 +16,10 @@
 
 namespace tool_encoded\output;
 
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->libdir . '/tablelib.php');
+
 use tool_encoded\helper;
 
 /**


### PR DESCRIPTION
Resolves #49 

Reproductsion/testing steps:
1. Spin up a clean MOODLE_401_STABLE
2. Install tool_encoded
3. Turn profiling off: `php admin/cli/cfg.php --name=profilingenabled --set=0`
4. Run scheduled task: `php admin/cli/scheduled_task.php --execute="\tool_encoded\task\queue_base64_report"`
Should result in the error: Class 'flexible_table' not found
5. Apply patch, task from 4 should run successfully