### PR TITLE
Fix set url warning

### DIFF
--- a/classes/output/summary.php
+++ b/classes/output/summary.php
@@ -33,6 +33,10 @@ class summary extends \table_sql {
 
         parent::__construct('tool_encoded_summary');
 
+        if (!$PAGE->has_set_url()) {
+            $PAGE->set_url(new moodle_url('/admin/tool/encoded/index.php'));
+        }
+
         $this->set_attribute('class', 'generaltable admintable w-auto');
         $this->define_columns(['report_table', 'report_column', 'count', 'max_size', 'total_size', 'mapped']);
         $this->define_headers([


### PR DESCRIPTION
Warning triggered via another scheduled task causes missing $PAGE context, e.g., 

078181569bb8:25773 2026-03-12 17:04:34 Processing question 'tool_mfa' in now of type (tool_beacon\question\config) payload is 188 bytes
078181569bb8:25773 2026-03-12 17:04:34 Processing question 'tool_mobile' in now of type (tool_beacon\question\config) payload is 247 bytes
078181569bb8:25773 2026-03-12 17:04:34 Processing question 'tool_moodlenet' in now of type (tool_beacon\question\config) payload is 208 bytes
078181569bb8:25773 2026-03-12 17:04:34 Processing question 'tool_objectfs' in now of type (tool_beacon\question\config) payload is 404 bytes
078181569bb8:25773 2026-03-12 17:04:34 Processing question 'tool_passwordvalidator' in now of type (tool_beacon\question\config) payload is 247 bytes
078181569bb8:25773 2026-03-12 17:04:35 Processing question 'status' in 0.938 secs of type (tool_beacon\question\check) payload is 2.6 KB
++ This page did not call $PAGE->set_url(...). Using  ++
* line 684 of /lib/pagelib.php: call to debugging()
* line 965 of /lib/pagelib.php: call to moodle_page->magic_get_url()
* line 50 of /admin/tool/encoded/classes/output/summary.php: call to moodle_page->__get()
* line 94 of /admin/tool/encoded/classes/check/base64check.php: call to tool_encoded\output\summary->__construct()
* line 56 of /admin/tool/beacon/classes/question/check.php: call to tool_encoded\check\base64check->get_result()
* line 70 of /admin/tool/beacon/classes/question/question.php: call to tool_beacon\question\check->query()
* line 112 of /admin/tool/beacon/classes/question/question.php: call to tool_beacon\question\question->answer()
* line 156 of /admin/tool/beacon/classes/processor.php: call to tool_beacon\question\question->get_structured_data()
* line 284 of /admin/tool/beacon/classes/processor.php: call to tool_beacon\processor->process_data()
* line 73 of /admin/tool/beacon/classes/task/signal_beacon.php: call to tool_beacon\processor->execute()
* line 410 of /lib/classes/cron.php: call to tool_beacon\task\signal_beacon->execute()
* line 194 of /admin/cli/scheduled_task.php: call to core\cron::run_inner_scheduled_task()
078181569bb8:25773 2026-03-12 17:04:43 Processing question 'performance' in 7.997 secs of type (tool_beacon\question\check) payload is 3.8 KB
078181569bb8:25773 2026-03-12 17:04:44 Processing question 'security' in 0.807 secs of type (tool_beacon\question\check) payload is 3.7 KB
078181569bb8:25773 2026-03-12 17:04:44 Processing question 'noemailever' in 0.001 secs of type (tool_beacon\question\sql_menu) payload is 167 bytes
078181569bb8:25773 2026-03-12 17:04:44 Processing question 'task_log' in 0.02 secs of type (tool_beacon\question\sql_menu) payload is 6.0 KB
078181569bb8:25773 2026-03-12 17:04:44 Processing question 'tool_encoded' in now of type (tool_beacon\question\sql_menu) payload is 675 bytes
078181569bb8:25773 2026-03-12 17:04:44 Processing question 'tool_excimer_memory' in now of type (tool_beacon\question\sql_menu) payload is 175 bytes
078181569bb8:25773 2026-03-12 17:04:44 Processing question 'tool_task_adhocids' in now of type (tool_beacon\question\sql_menu) payload is 280 bytes
