### PR TITLE
[#54] Fix class "tool_encoded\output\moodle_url" not found

### DIFF
--- a/classes/output/summary.php
+++ b/classes/output/summary.php
@@ -34,7 +34,7 @@ class summary extends \table_sql {
         parent::__construct('tool_encoded_summary');
 
         if (!$PAGE->has_set_url()) {
-            $PAGE->set_url(new moodle_url('/admin/tool/encoded/index.php'));
+            $PAGE->set_url(new \moodle_url('/admin/tool/encoded/index.php'));
         }
 
         $this->set_attribute('class', 'generaltable admintable w-auto');


### PR DESCRIPTION
Closes #54 

This merge request fixes class not found error.

This can be reproduced by:
1. Create local Moodle 4.5 environment.
2. Install plugins `tool_beacon` and `tool_encoded`.
3. Set 'beaconbaseurl' to 'https://localhost.com/'.
4. Set 'secretkey' to 'ioj23i2jmdkamdad' or anything...
5. Insert some dummy data into the database: 

```
INSERT INTO mdl_tool_encoded_base64_records
    (native_id, instance_id, pid, report_table, report_column, encoded_size, mimetype, migrated, timecreated, timemodified)
VALUES
    (1, 1, 0, 'workshop_assessments', 'feedbackauthor', 1024, 'image/gif', 0, EXTRACT(EPOCH FROM NOW())::BIGINT, EXTRACT(EPOCH FROM NOW())::BIGINT);
```

6. Add this file to reproduce error to the website root folder, name it `test_beacon_check.php`:

```
<?php
// Save as /var/www/html/test_beacon_check.php, run once, then delete
define('CLI_SCRIPT', true);
require __DIR__ . '/config.php';

$question = (object)[
    'id'         => 'performance',
    'type'       => 'check',
    'domain'     => 'test',
    'timestamp'  => time(),
    'params'     => (object)[],
];

$check = new \tool_beacon\question\check($question);
try {
    $data = $check->get_structured_data();
    echo "OK - no error\n";
} catch (\Throwable $e) {
    echo "ERROR: " . $e->getMessage() . "\n";
}
```

7. Run `test_beacon_check.php` before and after the fix:

```
root@xxxxxxx:/var/www/my-test-site# php test_beacon_check.php
ERROR: Class "tool_encoded\output\moodle_url" not found
root@xxxxxxx:/var/www/my-test-site# php test_beacon_check.php
OK - no error
root@xxxxxxx:/var/www/my-test-site#
```