### PR TITLE
Merge 501 branch updates with 401 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ contain base64 encoded data and then automated the fixing of this data back into
 
 | Moodle version | Branch                 | PHP  |
 |----------------|------------------------|------|
-| Moodle 5.1     | `MOODLE_501_STABLE`    | 8.2+ |
+| Moodle 5.1+    | `MOODLE_501_STABLE`    | 8.2+ |
 | Moodle 4.1-4.5 | `MOODLE_401_STABLE`    | 7.4+ |
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -15,10 +15,18 @@ https://tracker.moodle.org/browse/MDL-80104
 This is an admin tool for Moodle which provides a way to generate reports for columns that may
 contain base64 encoded data and then automated the fixing of this data back into normal plugin files.
 
+* [Branches](#branches)
 * [Installation](#installation)
 * [Usage](#usage)
 * [GDPR](#gdpr)
 * [Contributing and support](#contributing-and-support)
+
+## Branches
+
+| Moodle version | Branch                 | PHP  |
+|----------------|------------------------|------|
+| Moodle 5.1     | `MOODLE_501_STABLE`    | 8.2+ |
+| Moodle 4.1-4.5 | `MOODLE_401_STABLE`    | 7.4+ |
 
 ## Installation
 1. Clone this repository into admin/tool/encoded

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ contain base64 encoded data and then automated the fixing of this data back into
 
 | Moodle version | Branch                 | PHP  |
 |----------------|------------------------|------|
-| Moodle 5.1+    | `MOODLE_501_STABLE`    | 8.2+ |
+| Moodle 5.1+    | `MOODLE_401_STABLE`    | 8.2+ |
 | Moodle 4.1-4.5 | `MOODLE_401_STABLE`    | 7.4+ |
 
 ## Installation

--- a/tests/task/helper_test.php
+++ b/tests/task/helper_test.php
@@ -103,7 +103,8 @@ final class helper_test extends \advanced_testcase {
         $user = $this->getDataGenerator()->create_user();
         $this->getDataGenerator()->enrol_user($user->id, $course->id);
 
-        // Test mapping of question table to system context.
+        // Test mapping of question table to module context (qbank in site course).
+        // Since Moodle 5.1 question categories always live inside a qbank module context.
         $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
         $category = $questiongenerator->create_question_category();
         $question = $questiongenerator->create_question('multichoice', null, ['category' => $category->id]);
@@ -116,11 +117,11 @@ final class helper_test extends \advanced_testcase {
 
         $mapping = helper::get_mapping($record);
         $context = helper::get_variable_context($record, $mapping);
-        $systemcontext = \context_system::instance();
-        $this->assertEquals($systemcontext->contextlevel, $context->contextlevel);
-        $this->assertEquals($systemcontext->instanceid, $context->instanceid);
+        $expectedcontext = \context::instance_by_id($category->contextid);
+        $this->assertEquals($expectedcontext->contextlevel, $context->contextlevel);
+        $this->assertEquals($expectedcontext->instanceid, $context->instanceid);
 
-        // Test mapping of question table to course context.
+        // Test mapping of question table to module context (qbank in course).
         $coursecontext = \context_course::instance($course->id);
         $category = $questiongenerator->create_question_category(['contextid' => $coursecontext->id]);
         $question = $questiongenerator->create_question('multichoice', null, ['category' => $category->id]);
@@ -133,10 +134,11 @@ final class helper_test extends \advanced_testcase {
 
         $mapping = helper::get_mapping($record);
         $context = helper::get_variable_context($record, $mapping);
-        $this->assertEquals($coursecontext->contextlevel, $context->contextlevel);
-        $this->assertEquals($coursecontext->instanceid, $context->instanceid);
+        $expectedcontext = \context::instance_by_id($category->contextid);
+        $this->assertEquals($expectedcontext->contextlevel, $context->contextlevel);
+        $this->assertEquals($expectedcontext->instanceid, $context->instanceid);
 
-        // Test mapping of question type tables to course context.
+        // Test mapping of question type tables to module context (qbank in course).
         $category = $questiongenerator->create_question_category(['contextid' => $coursecontext->id]);
         $question = $questiongenerator->create_question('match', null, ['category' => $category->id]);
 
@@ -149,8 +151,9 @@ final class helper_test extends \advanced_testcase {
 
         $mapping = helper::get_mapping($record);
         $context = helper::get_variable_context($record, $mapping);
-        $this->assertEquals($coursecontext->contextlevel, $context->contextlevel);
-        $this->assertEquals($coursecontext->instanceid, $context->instanceid);
+        $expectedcontext = \context::instance_by_id($category->contextid);
+        $this->assertEquals($expectedcontext->contextlevel, $context->contextlevel);
+        $this->assertEquals($expectedcontext->instanceid, $context->instanceid);
 
         // Test mapping of grade grades to module context.
         $assign = $this->getDataGenerator()->create_module('assign', [

--- a/tests/task/migrate_test.php
+++ b/tests/task/migrate_test.php
@@ -63,9 +63,8 @@ final class migrate_test extends advanced_testcase {
     ): void {
         global $DB;
 
-        $this->setOutputCallback(function ($output) {
-            // Ignore output.
-        });
+        // Ignore output.
+        ob_start();
 
         $generator = self::getDataGenerator();
         $creator = $generator->get_plugin_generator($component);
@@ -145,6 +144,8 @@ final class migrate_test extends advanced_testcase {
                 );
             }
         }
+        // Ignore output.
+        ob_end_clean();
     }
 
     /**

--- a/tests/task/migrate_test.php
+++ b/tests/task/migrate_test.php
@@ -64,7 +64,7 @@ final class migrate_test extends advanced_testcase {
         global $DB;
 
         // Ignore output.
-        ob_start();
+        $this->expectOutputRegex('/.*/s');
 
         $generator = self::getDataGenerator();
         $creator = $generator->get_plugin_generator($component);
@@ -144,8 +144,6 @@ final class migrate_test extends advanced_testcase {
                 );
             }
         }
-        // Ignore output.
-        ob_end_clean();
     }
 
     /**

--- a/version.php
+++ b/version.php
@@ -26,5 +26,5 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'tool_encoded';
 $plugin->version = 20250102400;
-$plugin->requires = 2022112800;
-$plugin->supported = [401, 405];
+$plugin->requires = 2025100600;
+$plugin->supported = [501, 501];

--- a/version.php
+++ b/version.php
@@ -27,4 +27,4 @@ defined('MOODLE_INTERNAL') || die();
 $plugin->component = 'tool_encoded';
 $plugin->version = 20250102400;
 $plugin->requires = 2025100600;
-$plugin->supported = [501, 502];
+$plugin->supported = [401, 502];

--- a/version.php
+++ b/version.php
@@ -27,4 +27,4 @@ defined('MOODLE_INTERNAL') || die();
 $plugin->component = 'tool_encoded';
 $plugin->version = 20250102400;
 $plugin->requires = 2025100600;
-$plugin->supported = [501, 501];
+$plugin->supported = [501, 502];

--- a/version.php
+++ b/version.php
@@ -26,5 +26,5 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'tool_encoded';
 $plugin->version = 20250102400;
-$plugin->requires = 2025100600;
+$plugin->requires = 2022112800;
 $plugin->supported = [401, 502];


### PR DESCRIPTION
Hi team, 

After testing the updates on `MOODLE_501_STABLE` branch, we noticed that the changes there are supported in Moodle 4.1, 4.5. 

This PR cherry-picks the unit test fixes & documentation to the `MOODLE_401_STABLE` branch so that only one branch would need to be maintained for this plugin.

To validate these changes, please run unit tests in the Moodle 4.1 & Moodle 4.5 environments, and ensure the tests still pass in Moodle 5.1.

`vendor/bin/phpunit --testsuite tool_encoded_testsuite`

Once these changes are add to `MOODLE_401_STABLE` the `MOODLE_501_STABLE` branch can be removed.

Thank you!
